### PR TITLE
快捷选项(最近半小时等)跨天处理

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,10 @@
             max: '2019-04-29 20:59:59',
             isRange: true,
             shortcutOptions: [{
+                name: '最近18小时',
+                day: '0, 0',
+                time: [moment().subtract(18,'h').format("YYYY-MM-DD HH:mm:ss"), moment().format("YYYY-MM-DD HH:mm:ss")]
+            },{
               name: '昨天',
               day: '-1,-1',
               time: '00:00:00,23:59:59'

--- a/js/datapicker-separate/datepicker.js
+++ b/js/datapicker-separate/datepicker.js
@@ -606,11 +606,20 @@ $.extend(RangeDatePicker.prototype, {
       var end = moment().add(days[1], 'day').format(_this.config.format);
       if (_this.hasTime) {
         var times = $(this).data('time').split(',');
-        if (times[0]) {
-          begin = begin.split(' ')[0] + ' ' + times[0];
+       if (times[0]) {
+          if (times[0].length === 19){
+            begin = times[0];
+          } else {
+            begin = begin.split(' ')[0] + ' ' + times[0];
+          }
+
         }
         if (times[1]) {
-          end = end.split(' ')[0] + ' ' + times[1];
+          if (times[1].length === 19){
+            end = times[1];
+          } else {
+            end = end.split(' ')[0] + ' ' + times[1];
+          }
         }
       }
       _this.$inputBegin.val(begin);


### PR DESCRIPTION
新增快捷选项支持半小时、4小时等快捷选项（直接传 YYYY-MM-DD hh:mm:ss），原版半小时跨天日期修改逻辑不方便，新增最近18小时（跨天例子）